### PR TITLE
Specify package version for rpy2 in figures/requirements.txt.

### DIFF
--- a/figures/requirements.txt
+++ b/figures/requirements.txt
@@ -2,4 +2,4 @@ pandas
 matplotlib
 seaborn
 numpy
-rpy2
+rpy2<2.9.0


### PR DESCRIPTION
Python 2 is no longer supported by rpy2 starting with version 2.9.0. See https://bitbucket.org/rpy2/rpy2/issues/431/status-of-rpy2-on-python2.