### PR TITLE
Change pandas.Series.order() to pandas.Series.sort_values().

### DIFF
--- a/figures/generate_boxplot.py
+++ b/figures/generate_boxplot.py
@@ -108,7 +108,7 @@ if __name__ == '__main__':
         df_sort_by = df[(df.metric == measure) & (df.subset == "Test")]
         estimate_names = df_sort_by.score.groupby(
             df_sort_by.estimate_name
-        ).median().order().index.tolist()
+        ).median().sort_values().index.tolist()
 
         f, ax = plt.subplots(1, 1, figsize=fig_size)
 

--- a/figures/generate_boxplot_va.py
+++ b/figures/generate_boxplot_va.py
@@ -135,7 +135,7 @@ if __name__ == '__main__':
 
         estimate_names_u = df_u_sort_by.score.groupby(
             df_u_sort_by.estimate_name
-        ).median().order().index.tolist()
+        ).median().sort_values().index.tolist()
 
         df_u = df_u[df_u.metric == measure]
         ax_u = sns.boxplot(
@@ -162,7 +162,7 @@ if __name__ == '__main__':
         ]
         estimate_names_s = df_s_sort_by.score.groupby(
             df_s_sort_by.estimate_name
-        ).median().order().index.tolist()
+        ).median().sort_values().index.tolist()
 
         df_s = df_s[df_s.metric == measure]
 

--- a/figures/generate_stats.py
+++ b/figures/generate_stats.py
@@ -110,7 +110,7 @@ df_sort_by = df_sdr_vocals_test[
 
 sorted_estimates = df_sort_by.score.groupby(
    df_sort_by.estimate_name
-).median().order().index.tolist()
+).median().sort_values().index.tolist()
 
 sorted_indices = [axis_labels.index(label) for label in sorted_estimates]
 


### PR DESCRIPTION
The function pandas.Series.order() is deprecated since pandas 0.17.0. See http://pandas.pydata.org/pandas-docs/stable/whatsnew.html#changes-to-sorting-api.