### PR TITLE
Fix an index issue happened in multiple submissions

### DIFF
--- a/aggregate_data.py
+++ b/aggregate_data.py
@@ -64,9 +64,18 @@ class Data(object):
 
         for subset, subset_data in ndata.items():
             data = subset_data['results']
+            ibm_data = ibm_ndata[subset]['results']
+
             for track in range(data.shape[1]):
                 tdata = data[0, track][0, 0]
-                ibm_tdata = ibm_ndata[subset]['results'][0, track][0, 0]
+                ibm_tdata = ibm_data[0, track][0, 0]
+
+                # check title
+                if not difflib.get_close_matches(
+                        tdata['name'][0], [ibm_tdata['name'][0]], n=1):
+                    print 'WARNING: Title mismatch!\n\t%s: %s\n\t%s: %s' % \
+                        (filename, str(tdata['name'][0]),
+                         ibm_filename, str(ibm_tdata['name'][0]))
 
                 for target in [
                     'vocals', 'drums', 'other', 'bass', 'accompaniment'

--- a/aggregate_data.py
+++ b/aggregate_data.py
@@ -65,10 +65,19 @@ class Data(object):
         for subset, subset_data in ndata.items():
             data = subset_data['results']
             ibm_data = ibm_ndata[subset]['results']
+            ibm_titles = [ibm_data[0, idx][0, 0]['name'][0]
+                          for idx in range(ibm_data.shape[1])]
+            # correct title(s) in ibm_titles (not in ibm_data)
+            if subset == 'Dev':
+                ibm_titles[ibm_titles.index('Mu_TooBright_Full')] = \
+                    'Mu - Too Bright'
 
             for track in range(data.shape[1]):
                 tdata = data[0, track][0, 0]
-                ibm_tdata = ibm_data[0, track][0, 0]
+                ibm_track = ibm_titles.index(
+                    difflib.get_close_matches(
+                        tdata['name'][0], ibm_titles, n=1)[0])
+                ibm_tdata = ibm_data[0, ibm_track][0, 0]
 
                 # check title
                 if not difflib.get_close_matches(


### PR DESCRIPTION
I found that the track indexes from several submission MAT-files, i.e., CHA, GRA{2,3}, JEO{1,2}, KON, STO{1,2}, UHL{1,2,3}, don't match those from the IBM MAT-file. Because of this issue, [these lines](https://github.com/faroit/sisec-mus-results/blob/5ea99eb8f02a53d405e82e1d0ca1a9b1ffe610d0/aggregate_data.py#L68-L69) result in a couple of data for different tracks, which should not happen. This PR essentially modifies the above two lines so that they use different track indexes to obtain a couple of data for the correct track.